### PR TITLE
Disable submit button when `slackToken` is not set

### DIFF
--- a/src/Feedback.module.css
+++ b/src/Feedback.module.css
@@ -86,8 +86,12 @@
 }
 
 .submit {
-  background-color: #BB6BD9;
+  background-color: rgb(187, 107, 217);
   color: white;
+}
+
+.submit:disabled {
+  background-color: rgba(187, 107, 217, 40%);
 }
 
 .cancel {

--- a/src/Feedback.tsx
+++ b/src/Feedback.tsx
@@ -306,13 +306,15 @@ export default function Feedback({
             <textarea
               autoFocus={true}
               className={styles.textInput}
+              disabled={!slackToken}
               onChange={handleFeedbackTextChange}
-              placeholder="We’d love to hear your feedback! Tell us what you’re thinking."
+              placeholder={slackToken ? "We’d love to hear your feedback! Tell us what you’re thinking." : "Set a Slack Token to enable!"}
               rows={4}
               value={feedbackText}
             />
             <button
               className={`${styles.btn} ${styles.submit}`}
+              disabled={!slackToken}
               onClick={submitFeedback}
             >Submit</button>
             <button


### PR DESCRIPTION
This prevents the component from hitting the Slack API with what is guaranteed to be an error.
Hopefully avoids a situation where the user spends time writing feedback without being able to submit!